### PR TITLE
Add simple dynamic memory management to `libc/mem.c`

### DIFF
--- a/cpu/type.h
+++ b/cpu/type.h
@@ -13,4 +13,6 @@ typedef          char  s8;
 #define low_16(address) (u16)((address) & 0xFFFF)
 #define high_16(address) (u16)(((address) >> 16) & 0xFFFF)
 
+#define NULL 0
+
 #endif

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -2,6 +2,7 @@
 #include "../cpu/timer.h"
 #include "../drivers/screen.h"
 #include "../libc/string.h"
+#include "../libc/mem.h"
 
 void main() {
     isr_install();
@@ -9,15 +10,34 @@ void main() {
     clear_screen();
 
     kprint("Kernel input\n"
-           "Type DIE to halt the CPU \n >");
+           "Type DIE to halt the CPU \n > ");
 }
 
 void user_input(char *input) {
     if (strcmp(input, "DIE") == 0) {
         kprint("Stopping the CPU. Bye!\n");
         asm volatile("hlt");
+    } else if (strcmp(input, "AL") == 0) {
+        char *test = (char*) kmalloc(6*sizeof(char));
+        if (test == NULL) {
+            kprint("bad");
+        }
+        char h[] = "hello\n";
+        strcopy(test, h);
+        kprint(test);
+        free(test);
+        test = NULL;
+        test = (char*) kmalloc(5*sizeof(char));
+        char t[] = "test";
+        strcopy(test, t);
+        kprint(test);
+        free(test);
+        test = NULL;
+        test = (char*) kmalloc(5*sizeof(char));
+        char c[] = "capt";
+        strcopy(test, c);
+        kprint(test);
+        free(test);
     }
-    kprint("You said: ");
-    kprint(input);
-    kprint("\n> ");
+    kprint("\n > ");
 }

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -9,35 +9,16 @@ void main() {
     irq_install();
     clear_screen();
 
-    kprint("Kernel input\n"
-           "Type DIE to halt the CPU \n > ");
+    kprint("Ready for input\n"
+           "Type DIE to halt the CPU \n"
+           "> "
+    );
 }
 
 void user_input(char *input) {
     if (strcmp(input, "DIE") == 0) {
-        kprint("Stopping the CPU. Bye!\n");
+        kprint("Stopping the CPU\n");
         asm volatile("hlt");
-    } else if (strcmp(input, "AL") == 0) {
-        char *test = (char*) kmalloc(6*sizeof(char));
-        if (test == NULL) {
-            kprint("bad");
-        }
-        char h[] = "hello\n";
-        strcopy(test, h);
-        kprint(test);
-        free(test);
-        test = NULL;
-        test = (char*) kmalloc(5*sizeof(char));
-        char t[] = "test";
-        strcopy(test, t);
-        kprint(test);
-        free(test);
-        test = NULL;
-        test = (char*) kmalloc(5*sizeof(char));
-        char c[] = "capt";
-        strcopy(test, c);
-        kprint(test);
-        free(test);
     }
     kprint("\n > ");
 }

--- a/libc/mem.c
+++ b/libc/mem.c
@@ -12,3 +12,80 @@ void memory_set(u8 *dest, u8 val, u32 len) {
     u8 *temp = (u8 *)dest;
     for ( ; len != 0; len--) *temp++ = val;
 }
+
+// head of linkedlist
+u32 free_mem_addr = 0x10000;
+
+typedef struct memory_sector {
+    struct memory_sector *next;
+    u32 is_used;
+    u32 pages;
+} MEM_SEC;
+
+u32 PAGE_SIZE = 0x1000;
+u32 calculate_pages_num(u32 size) {
+    u32 pages_num = size / PAGE_SIZE;
+    if ((size % PAGE_SIZE) > 0)
+        pages_num++;
+    return pages_num;
+}
+
+MEM_SEC *find_empty_slot(u32 pages_num) {
+    MEM_SEC *p = (MEM_SEC*) free_mem_addr;
+    while (p != NULL) {
+        if (p->is_used == 0 && p->pages >= pages_num)
+            return p;
+        p = p->next;
+    }
+    return NULL;
+}
+
+MEM_SEC *find_last_slot() {
+    MEM_SEC *p = (MEM_SEC*) free_mem_addr;
+    while (p != NULL)
+        if (p->next == NULL)
+            return p;
+    return NULL;
+}
+
+void insert(u32 addr, u32 pages) {
+    MEM_SEC *new_slot = (MEM_SEC*) addr;
+    new_slot->is_used = 1;
+    new_slot->pages = pages;
+    new_slot->next = NULL;
+}
+
+void free(void *addr) {
+    MEM_SEC *p = (MEM_SEC*) free_mem_addr;
+    while (p != NULL) {
+        if (((u32) p + sizeof(MEM_SEC)) == (u32) addr) {
+            p->is_used = 0;
+            return;
+        }
+        p = p->next;
+    }
+}
+
+u32 kmalloc(u32 size) {
+    u32 pages_num = calculate_pages_num(size);
+
+    // it is a first time we allocate memory
+    if (free_mem_addr == 0x10000) {
+        free_mem_addr += 1;
+        MEM_SEC *msec = (MEM_SEC*) free_mem_addr;
+        msec->next = NULL;
+        msec->is_used = 1;
+        msec->pages = pages_num;
+        return (u32) msec + (u32) sizeof(MEM_SEC);
+    } else {
+        MEM_SEC *slot = find_empty_slot(pages_num);
+        if (slot == NULL) {
+            slot = find_last_slot();
+            u32 new_addr = (u32) slot + sizeof(MEM_SEC) + slot->pages * PAGE_SIZE;
+            insert(new_addr, pages_num);
+            return (u32) new_addr + (u32) sizeof(MEM_SEC) + (u32) pages_num * PAGE_SIZE;
+        }
+        slot->is_used = 1;
+        return (u32) slot + (u32) sizeof(MEM_SEC);
+    }
+}

--- a/libc/mem.h
+++ b/libc/mem.h
@@ -5,5 +5,9 @@
 
 void memory_copy(u8 *source, u8 *dest, int nbytes);
 void memory_set(u8 *dest, u8 val, u32 len);
+void free(void *addr);
+u32 kmalloc(u32 size);
+
+#define NULL 0
 
 #endif

--- a/libc/mem.h
+++ b/libc/mem.h
@@ -8,6 +8,4 @@ void memory_set(u8 *dest, u8 val, u32 len);
 void free(void *addr);
 u32 kmalloc(u32 size);
 
-#define NULL 0
-
 #endif


### PR DESCRIPTION
Add two public functions to `libc/mem.c`:
1. _kmalloc()_, for dynamic memory allocation
2. _free()_, for freeing a dynamically allocated pointer

Memory allocation is based on a growing linked list of allocated memory sectors that can be freed and reused. The solution is sufficient for this initial stage and in the future can be improved with a more sophisticated allocation algorithm.